### PR TITLE
Fix link in 68N15-C.tex

### DIFF
--- a/68N15-C.tex
+++ b/68N15-C.tex
@@ -76,7 +76,7 @@ int main() {
 \end{verbatim}
 
 This program works pretty much the same as 
-\PMlinkname{the corresponding C example}{CProgrammingLanguage}.
+\PMlinkname{the corresponding C example}{C1}.
 Instead of C's standard I/O library, the program uses 
 C++'s \verb=iostream= library. 
 A substantial difference between the two programs


### PR DESCRIPTION
The C programming language is listed under C1, not CProgrammingLanguage